### PR TITLE
Fix Timer.fmt for short result strings

### DIFF
--- a/fs/api_timer.js
+++ b/fs/api_timer.js
@@ -43,7 +43,7 @@ let Timer = {
   // ```
   fmt: function(fmt, time) {
     if (!fmt) return 'invalid format';
-    let res = 0, t = Math.round(time || Timer.now()), s = '     ';
+    let res = 0, t = Math.round(time || Timer.now()), s = '      ';
     while (res === 0) {
       res = this._f(s, s.length, fmt, t);
       if (res === -1) return 'invalid time';


### PR DESCRIPTION
When doing eg. `Timer.fmt('%H', Timer.now())` the resulting string is `  `.
Test code:
```
    let now = Timer.now();
    let hour = Timer.fmt("%H", now);
    print('++++', JSON.stringify({hour: hour}));
```
Original `Timer.fmt` output:
```
{"hour":"  "}
```
Modified:
```
{"hour":"20"}
```

