### PR TITLE
Fix Sys.malloc comment

### DIFF
--- a/fs/api_sys.js
+++ b/fs/api_sys.js
@@ -12,7 +12,7 @@ let Sys = {
     return buf;
   },
 
-  // ## **`Sys.calloc(nmemb, size)`**
+  // ## **`Sys.malloc(size)`**
   // Allocate a memory region.
   // Note: currently memory allocated this way must be explicitly released with
   // `free()`.


### PR DESCRIPTION
The comment mentions `calloc`, but the ffi-ed function is `malloc`